### PR TITLE
Load sounds right after they are played to avoid delay

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -330,7 +330,9 @@ CM.init = function() {
 
 	// Cache the audio alert sound files
 	this.config.cmGCAudioObject = new Audio(this.config.cmGCAudioAlertURL);
+	this.config.cmGCAudioObject.load();
 	this.config.cmSPAudioObject = new Audio(this.config.cmSPAudioAlertURL);
+	this.config.cmSPAudioObject.load();
 
 	// Ensure CM can run correctly
 	if(this.integrityCheck()) {

--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -1790,9 +1790,9 @@ CM.playAudioAlerts = function() {
 		if(Game.goldenCookie.life > 0) {
 
 			if(!gcNotified) {
-				gcAlert.load();
 				gcAlert.volume = volume;
 				gcAlert.play();
+	      setTimeout(function() { gcAlert.load() }, 1500);
 				this.config.cmAudioGCNotified = true;
 			}
 
@@ -1811,9 +1811,9 @@ CM.playAudioAlerts = function() {
 
 			if(!spNotified) {
 
-				spAlert.load();
 				spAlert.volume = volume;
 				spAlert.play();
+	      setTimeout(function() { spAlert.load() }, 1500);
 				this.config.cmAudioSPNotified = true;
 
 			}


### PR DESCRIPTION
Alert sounds are loaded right after being played (and before the first play).

This can avoid some delays caused by sound loading.
