### PR TITLE
Display trailing zeroes in shortened large numbers

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -493,7 +493,8 @@ CM.largeNumFormat = function(num, precision) {
 	if(useShortNums) {
 		for(i = 0; i < ranges.length; i++) {
 			if(num >= ranges[i].divider) {
-				num = Math.floor((num / ranges[i].divider) * Math.pow(10, largeFloats)) / Math.pow(10, largeFloats) + ranges[i].suffix[notation];
+				num = Math.floor((num / ranges[i].divider) * Math.pow(10, largeFloats)) / Math.pow(10, largeFloats);
+				num = num.toFixed(largeFloats) + ranges[i].suffix[notation];
 				return qualifier + num.replace('.', decimal);
 			}
 		}


### PR DESCRIPTION
Fixes number shortening to show decimal places matching the precision setting
for large numbers.

![fix](https://f.cloud.github.com/assets/2757386/1913684/895c0638-7d4c-11e3-82f5-a272563e9dda.png)
