### PR TITLE
Display the actual amount of cookies sucked by wrinklers

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -1768,6 +1768,13 @@ CM.testAudioObject = function(obj) {
 
 };
 
+
+/**
+ * Stores the actual amount of cookies sucked by each wrinkler
+ */ 
+CM.actualCookiesSucked = [0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0];
+
 /* ================================================
     NON-RETURNING METHODS
 
@@ -1786,6 +1793,15 @@ CM.mainLoop = function() {
 
     // Update timers
     this.updateTimers();
+
+    // Update cookies sucked by wrinklers
+    $.each(Game.wrinklers, function() {
+        if (this.close == 0) {
+            CM.actualCookiesSucked[this.id] = 0;
+        } else {
+            CM.actualCookiesSucked[this.id] += Game.cookiesPs * 0.05;
+        }
+    });
 
     // Update GC Display timer
     if(settings.showGCCountdown.current === 'on') {

--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -1438,7 +1438,9 @@ CM.getWrinklerStats = function() {
         sucked += this.sucked;
     });
 
-    return [sucked, sucked * rewardMultiplier];
+    return [CM.actualCookiesSucked.reduce(function(acc, n) {
+        return acc + n;
+    }, 0), sucked * rewardMultiplier];
 
 };
 
@@ -1796,7 +1798,7 @@ CM.mainLoop = function() {
 
     // Update cookies sucked by wrinklers
     $.each(Game.wrinklers, function() {
-        if (this.close == 0) {
+        if (this.phase != 2) {
             CM.actualCookiesSucked[this.id] = 0;
         } else {
             CM.actualCookiesSucked[this.id] += Game.cookiesPs * 0.05;


### PR DESCRIPTION
As discussed in https://github.com/greenc/CookieMaster/issues/47, the "cookies sucked by wrinklers" statistics should display the actual amount that was sucked.
