### PR TITLE
Fix for new seasons being added not breaking cost

### DIFF
--- a/src/external-methods.js
+++ b/src/external-methods.js
@@ -730,7 +730,7 @@ CME.simulateBuy = function(object, statistic) {
     }
 
     // Don't simulate seasonal upgrades or Elder pledge/Covenant
-    var doNotSimulate = [74, 84, 85, 181, 182, 183, 184];
+    var doNotSimulate = [74, 84, 85, 181, 182, 183, 184, 185];
     if(doNotSimulate.indexOf(object.id) !== -1) {
         return 0;
     }
@@ -744,6 +744,7 @@ CME.simulateBuy = function(object, statistic) {
             Collect     : Game.CollectWrinklers
         },
         stored = {
+            seasonUses       : Game.seasonUses,
             cpsSucked        : Game.cpsSucked,
             globalCpsMult    : Game.globalCpsMult,
             cookiesPs        : Game.cookiesPs,
@@ -772,6 +773,7 @@ CME.simulateBuy = function(object, statistic) {
 
     // Reverse buy
     object.simulateToggle(false);
+    Game.seasonUses       = stored.seasonUses;
     Game.cpsSucked        = stored.cpsSucked;
     Game.globalCpsMult    = stored.globalCpsMult;
     Game.cookiesPs        = stored.cookiesPs;


### PR DESCRIPTION
Simulated purchase of upgrades breaks the cost of seasons due to a new season being added, and the seasonUses not being swapped. This fixes that.
