### PR TITLE
Fix TrueCps and Click Tracking issues

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -2206,7 +2206,7 @@ CM.TrueCps = function(interval, maxTime) {
 
         // Add up values
         for(i = 0; i < len; i++) {
-            sum += parseInt(tracked[i], 10);
+            sum += tracked[i];
         }
 
         // Get the mean average
@@ -2338,7 +2338,7 @@ CM.ClickTracker = function(interval, maxTime) {
 
         // Add up values
         for(i = 0; i < len; i++) {
-            sum += parseInt(tracked[i], 10);
+            sum += tracked[i];
         }
 
         // Get the mean average


### PR DESCRIPTION
Tracking duration was being ignored, and extra timeouts were being created every time the settings were saved.

Saving the settings will no longer clear the tracking data, and resetting the game will clear it.
Also, use of parseInt was causing erroneous calculations when dealing with numbers large enough for javascript to express in scientific notation.
