### PR TITLE
Added Season Timer and Helper

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -205,6 +205,24 @@ CM.config = {
         pledge: {
             label: 'Pledge:'
         },
+        season: {
+            label: function() {
+                    switch (Game.season) {
+                    case 'christmas':
+                        return 'Christmas:';
+                    case 'easter':
+                        return 'Easter:';
+                    case 'fools':
+                        return 'Fools\' Day:';
+                    case 'halloween':
+                        return 'Halloween:';
+                    case 'valentines':
+                        return 'Valentine\'s Day:';
+                    default:
+                        return 'Season:';
+                    }
+                }
+        },
         wrinklers: {
             label: 'Pop Wrinklers:'
         }
@@ -501,6 +519,13 @@ CM.config = {
             desc:    'Display time remaining for Elder Pledge when active.',
             current: 'on'
         },
+        showSeasonTimer: {
+            group:   'alerts',
+            type:    'checkbox',
+            label:   'Show Season Timer:',
+            desc:    'Display time remaining for the current season.',
+            current: 'off'
+        },
         showGCCountdown: {
             group:   'alerts',
             type:    'checkbox',
@@ -603,6 +628,39 @@ CM.config = {
             type:  'checkbox',
             label: 'Auto-buy Santa Unlocks:',
             desc:  'Automatically buy the Santa unlocks when they become available.',
+            current: 'off'
+        },
+        autoSeason: {
+            group: 'helpers',
+            type:  'select',
+            label: 'Maintain Season',
+            desc:  'Automatically buy the appropriate Season biscuit.',
+            options: [
+                  {
+                      label: 'Off',
+                      value: 'off'
+                  },
+                  {
+                      label: 'Christmas',
+                      value: 'christmas'
+                  },
+                  {
+                      label: 'Easter',
+                      value: 'easter'
+                  },
+                  {
+                      label: 'Fools\' Day',
+                      value: 'fools'
+                  },
+                  {
+                      label: 'Halloween',
+                      value: 'halloween'
+                  },
+                  {
+                      label: 'Valentine\'s Day',
+                      value: 'valentines'
+                  }
+              ],
             current: 'off'
         },
         popWrinklersAtInterval: {
@@ -987,14 +1045,23 @@ CM.largeNumFormat = function(num, precision) {
 CM.Timer = function(type, label) {
 
     this.type      = type;
-    this.label     = label;
+    this.labelFn   = null;
+    this.label     = '';
     this.id        = 'CMTimer-' + this.type;
     this.container = {};
     this.barOuter  = {};
     this.barInner  = {};
     this.counter   = {};
+    this.labelDiv  = {};
     this.limiter   = null; // Add only if needed
 
+    if (typeof label === 'function') {
+        this.labelFn = label;
+        this.label = this.labelFn.call(this);
+    } else {
+        this.label = label;
+    }
+    
     /**
      * Create a new timer object
      * @return {Object} Timer HTML as jQuery object
@@ -1036,6 +1103,7 @@ CM.Timer = function(type, label) {
         this.barOuter  = $barOuter;
         this.barInner  = $barInner;
         this.counter   = $counter;
+        this.labelDiv  = $label;
         this.limiter   = $limiter;
 
         return $container;
@@ -1080,6 +1148,10 @@ CM.Timer = function(type, label) {
 
         this.barInner.css('width', width + '%');
         this.counter.text(Math.round(timings.minCurrent));
+        if (this.labelFn != null) {
+            this.label = this.labelFn.call(this);
+            this.labelDiv.text(this.label);
+        }
 
         return this;
 
@@ -1121,6 +1193,9 @@ CM.Timer = function(type, label) {
         } else if(this.type === 'pledge') {
             timings.minCurrent = Game.pledgeT / Game.fps;
             timings.max = 60 * maxPledge;
+        } else if(this.type === 'season') {
+            timings.minCurrent = Game.seasonT / Game.fps;
+            timings.max = 60*60*24;
         } else if(this.type === 'wrinklers') {
             timings.minCurrent = (CM.popWrinklersTime - time) / 1000;
             timings.max = WrinklerT / 1000;
@@ -2454,6 +2529,11 @@ CM.mainLoop = function() {
         this.autoBuyPledge();
     }
 
+    // Auto-Season
+    if(settings.autoSeason.current !== 'off') {
+        this.autoBuySeason();
+    }
+
     // Click santa if it exists and we haven't reached max level
     if(settings.clickSanta.current === 'on' && Game.Has('A festive hat') && Game.santaLevel < 14) {
         this.clickSanta();
@@ -3115,6 +3195,7 @@ CM.populateTimerPanel = function() {
     activeTimers.clickFrenzy = settings.showClickFrenzyTimer.current;
     activeTimers.clot        = settings.showClotTimer.current;
     activeTimers.pledge      = settings.showPledgeTimer.current;
+    activeTimers.season      = settings.showSeasonTimer.current;
 
     // Create timer for Wrinkler auto-pop feature
     if(settings.popWrinklersAtInterval.current !== 'off') {
@@ -3149,6 +3230,7 @@ CM.updateTimers = function() {
             elderFrenzy: Game.frenzy > 0 && Game.frenzyPower === 666,
             clot:        Game.frenzy > 0 && Game.frenzyPower === 0.5,
             pledge:      Game.pledgeT > 0,
+            season:      Game.seasonT > 0 && Game.season != Game.baseSeason,
             wrinklers:   CM.popWrinklersTimeRelative > 0
         },
         key;
@@ -3414,6 +3496,22 @@ CM.autoBuyPledge = function() {
     }
 
 };
+
+CM.autoBuySeason = function() {
+    var trigger = Game.Upgrades[Game.seasons[this.config.settings.autoSeason.current].trigger],
+    switcher    = Game.Upgrades['Season switcher'],
+    inStore     = trigger.isInStore();
+    price       = trigger.getPrice(),
+    bank        = Game.cookies;
+
+    if (switcher.isInStore() && switcher.getPrice() < bank) {
+        switcher.buy();
+        bank = Game.cookies;
+    }
+    if(inStore && price < bank && Game.season != this.config.settings.autoSeason.current) {
+        trigger.buy();
+    }
+}
 
 /**
  * Adds a button to pop all existing wrinklers


### PR DESCRIPTION
Added select box to Helper settings to auto-buy season upgrades.
Added check box to Timer settings to add a Season timer (resolves #67).
Timer label may now be either a function, to allow for dynamic labels.
