### PR TITLE
Fixed simulation bug with Century egg

### DIFF
--- a/src/cookiemaster.js
+++ b/src/cookiemaster.js
@@ -879,6 +879,9 @@ CM.init = function() {
     if(Game.seasonPopup.maxTime === 0 && Game.goldenCookie.maxTime === 0) {
         this.fixNewGameSpawns();
     }
+    
+    // Miscellaneous member variables
+    this.lastRecalculatedDekasecond = 0; // For keeping simulations accurate with Century egg
 
     // All done :)
     this.popup('CookieMaster v.' + this.config.version + ' loaded successfully!', 'notice');

--- a/src/external-methods.js
+++ b/src/external-methods.js
@@ -832,7 +832,10 @@ CME.simulateBuy = function(object, statistic, avoidRecursion) {
         return 0;
     }
 
+    // Century egg can cause a change to CpS without the recalculateGains flag being set.
+    // We need to make sure the egg's bonus is baked in before we begin the simulation.
     if (Game.Has('Century egg')) {
+        // Bonus increases every 10 seconds.
         var dekasecond = Math.floor((new Date().getTime()-Game.startDate)/10000);
         if (CM.lastRecalculatedDekasecond < dekasecond) {
             CM.lastRecalculatedDekasecond = dekasecond;

--- a/src/external-methods.js
+++ b/src/external-methods.js
@@ -817,7 +817,7 @@ CMEO.isInStore = function() {
  *
  * @return {Integer}
  */
-CME.simulateBuy = function(object, statistic) {
+CME.simulateBuy = function(object, statistic, avoidRecursion) {
 
     // Store initial state
     ////////////////////////////////////////////////////////////////////
@@ -832,6 +832,13 @@ CME.simulateBuy = function(object, statistic) {
         return 0;
     }
 
+    if (Game.Has('Century egg')) {
+        var dekasecond = Math.floor((new Date().getTime()-Game.startDate)/10000);
+        if (CM.lastRecalculatedDekasecond < dekasecond) {
+            CM.lastRecalculatedDekasecond = dekasecond;
+            Game.recalculateGains = 1;
+        }
+    }
     if (Game.recalculateGains) Game.CalculateGains();
     
     // Disable some native methods
@@ -890,6 +897,15 @@ CME.simulateBuy = function(object, statistic) {
     Game.Win              = swapped.Win;
     Game.Unlock           = swapped.Unlock;
     Game.CollectWrinklers = swapped.Collect;
+
+    if (Game.Has('Century egg')) {
+        var dekasecond = Math.floor((new Date().getTime()-Game.startDate)/10000);
+        if (CM.lastRecalculatedDekasecond < dekasecond) {
+            // New dekasecond since we started the simulation--no idea if it caused an error
+            // Redo it just in case, but don't get caught in a loop
+            if (!avoidRecursion) return this.simulateBuy(object, statistic, 1);
+        }
+    }
 
     return income - Game[statistic];
 };


### PR DESCRIPTION
Century egg was causing problems for simulateBuy.  We'll now check to
make sure an increased bonus from the Century egg doesn't interfere with
the simulation.
